### PR TITLE
Decouple service client

### DIFF
--- a/src/controllers/QueryNotificationHandler.ts
+++ b/src/controllers/QueryNotificationHandler.ts
@@ -3,7 +3,7 @@
 *  service layer
 */
 import QueryRunner from './QueryRunner';
-import SqlToolsServiceClient from '../languageservice/serviceclient';
+import { ServiceClientLocator } from '../languageservice/serviceclient';
 import {
     QueryExecuteCompleteNotification,
     QueryExecuteBatchStartNotification,
@@ -34,11 +34,11 @@ export class QueryNotificationHandler {
 
     // register the handler to handle notifications for queries
     private initialize(): void {
-        SqlToolsServiceClient.instance.onNotification(QueryExecuteCompleteNotification.type, this.handleQueryCompleteNotification());
-        SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchStartNotification.type, this.handleBatchStartNotification());
-        SqlToolsServiceClient.instance.onNotification(QueryExecuteBatchCompleteNotification.type, this.handleBatchCompleteNotification());
-        SqlToolsServiceClient.instance.onNotification(QueryExecuteResultSetCompleteNotification.type, this.handleResultSetCompleteNotification());
-        SqlToolsServiceClient.instance.onNotification(QueryExecuteMessageNotification.type, this.handleMessageNotification());
+        ServiceClientLocator.instance.onNotification(QueryExecuteCompleteNotification.type, this.handleQueryCompleteNotification());
+        ServiceClientLocator.instance.onNotification(QueryExecuteBatchStartNotification.type, this.handleBatchStartNotification());
+        ServiceClientLocator.instance.onNotification(QueryExecuteBatchCompleteNotification.type, this.handleBatchCompleteNotification());
+        ServiceClientLocator.instance.onNotification(QueryExecuteResultSetCompleteNotification.type, this.handleResultSetCompleteNotification());
+        ServiceClientLocator.instance.onNotification(QueryExecuteMessageNotification.type, this.handleMessageNotification());
     }
 
     // Registers queryRunners with their uris to distribute notifications.

--- a/src/controllers/QueryRunner.ts
+++ b/src/controllers/QueryRunner.ts
@@ -2,7 +2,7 @@
 import { EventEmitter } from 'events';
 
 import StatusView from '../views/statusView';
-import SqlToolsServerClient from '../languageservice/serviceclient';
+import { ISqlToolsServiceClient, ServiceClientLocator } from '../languageservice/serviceclient';
 import {QueryNotificationHandler} from './QueryNotificationHandler';
 import VscodeWrapper from './vscodeWrapper';
 import { BatchSummary, QueryExecuteParams, QueryExecuteRequest,
@@ -42,11 +42,11 @@ export default class QueryRunner {
     constructor(private _ownerUri: string,
                 private _editorTitle: string,
                 private _statusView: StatusView,
-                private _client?: SqlToolsServerClient,
+                private _client?: ISqlToolsServiceClient,
                 private _notificationHandler?: QueryNotificationHandler,
                 private _vscodeWrapper?: VscodeWrapper) {
         if (!_client) {
-            this._client = SqlToolsServerClient.instance;
+            this._client = ServiceClientLocator.instance;
         }
 
         if (!_notificationHandler) {

--- a/src/controllers/connectionManager.ts
+++ b/src/controllers/connectionManager.ts
@@ -9,7 +9,7 @@ import Interfaces = require('../models/interfaces');
 import { ConnectionStore } from '../models/connectionStore';
 import { ConnectionUI } from '../views/connectionUI';
 import StatusView from '../views/statusView';
-import SqlToolsServerClient from '../languageservice/serviceclient';
+import { ISqlToolsServiceClient, ServiceClientLocator } from '../languageservice/serviceclient';
 import { IPrompter } from '../prompts/question';
 import Telemetry from '../models/telemetry';
 import VscodeWrapper from './vscodeWrapper';
@@ -74,7 +74,7 @@ export default class ConnectionManager {
     constructor(context: vscode.ExtensionContext,
                 statusView: StatusView,
                 prompter: IPrompter,
-                private _client?: SqlToolsServerClient,
+                private _client?: ISqlToolsServiceClient,
                 private _vscodeWrapper?: VscodeWrapper,
                 private _connectionStore?: ConnectionStore) {
         this._context = context;
@@ -83,7 +83,7 @@ export default class ConnectionManager {
         this._connections = {};
 
         if (!this.client) {
-            this.client = SqlToolsServerClient.instance;
+            this.client = ServiceClientLocator.instance;
         }
         if (!this.vscodeWrapper) {
             this.vscodeWrapper = new VscodeWrapper();
@@ -119,14 +119,14 @@ export default class ConnectionManager {
     /**
      * Exposed for testing purposes
      */
-    public get client(): SqlToolsServerClient {
+    public get client(): ISqlToolsServiceClient {
         return this._client;
     }
 
     /**
      * Exposed for testing purposes
      */
-    public set client(client: SqlToolsServerClient) {
+    public set client(client: ISqlToolsServiceClient) {
         this._client = client;
     }
 

--- a/src/controllers/mainController.ts
+++ b/src/controllers/mainController.ts
@@ -11,7 +11,7 @@ import Utils = require('../models/utils');
 import { SqlOutputContentProvider } from '../models/SqlOutputContentProvider';
 import StatusView from '../views/statusView';
 import ConnectionManager from './connectionManager';
-import SqlToolsServerClient from '../languageservice/serviceclient';
+import { ServiceClientLocator } from '../languageservice/serviceclient';
 import { IPrompter } from '../prompts/question';
 import CodeAdapter from '../prompts/adapter';
 import Telemetry from '../models/telemetry';
@@ -134,7 +134,7 @@ export default class MainController implements vscode.Disposable {
 
         // initialize language service client
         return new Promise<boolean>( (resolve, reject) => {
-                SqlToolsServerClient.instance.initialize(self._context).then(serverResult => {
+                ServiceClientLocator.instance.initialize(self._context).then(serverResult => {
 
                 // Init status bar
                 self._statusview = new StatusView();

--- a/src/credentialstore/credentialstore.ts
+++ b/src/credentialstore/credentialstore.ts
@@ -6,7 +6,7 @@
 
 import * as Contracts from '../models/contracts';
 import { ICredentialStore } from './icredentialstore';
-import SqlToolsServerClient from '../languageservice/serviceclient';
+import { ISqlToolsServiceClient, ServiceClientLocator } from '../languageservice/serviceclient';
 
 /**
  * Implements a credential storage for Windows, Mac (darwin), or Linux.
@@ -15,9 +15,9 @@ import SqlToolsServerClient from '../languageservice/serviceclient';
  */
 export class CredentialStore implements ICredentialStore {
 
-    constructor(private _client?: SqlToolsServerClient) {
+    constructor(private _client?: ISqlToolsServiceClient) {
         if (!this._client) {
-            this._client = SqlToolsServerClient.instance;
+            this._client = ServiceClientLocator.instance;
         }
     }
 

--- a/src/languageservice/bigquery.ts
+++ b/src/languageservice/bigquery.ts
@@ -1,0 +1,96 @@
+'use strict';
+
+import { ExtensionContext, window, OutputChannel } from 'vscode';
+import {
+    LanguageClient, LanguageClientOptions, ServerOptions,
+    TransportKind, RequestType, NotificationType, NotificationHandler
+} from 'vscode-languageclient';
+
+import {Logger} from '../models/logger';
+import Constants = require('../models/constants');
+import { ServerInitializationResult } from './serverStatus';
+import StatusView from '../views/statusView';
+import * as LanguageServiceContracts from '../models/contracts/languageService';
+import * as path from 'path';
+import { ISqlToolsServiceClient } from './serviceclient';
+
+
+let _channel: OutputChannel = undefined;
+
+export default class BigQueryServiceClient implements ISqlToolsServiceClient {
+    private static _instance: BigQueryServiceClient = undefined;
+    private _client: LanguageClient;
+    public static get instance(): BigQueryServiceClient {
+        if (this._instance === undefined) {
+            _channel = window.createOutputChannel(Constants.serviceInitializingOutputChannelName);
+            let logger = new Logger(text => _channel.append(text));
+            let statusView = new StatusView();
+            this._instance = new BigQueryServiceClient(logger, statusView);
+        }
+        return this._instance;
+    }
+
+    constructor(
+        private _logger: Logger,
+        private _statusView: StatusView) {
+    }
+
+    public initialize(context: ExtensionContext): Promise<ServerInitializationResult> {
+        this._logger.appendLine(Constants.serviceInitializing);
+        return new Promise<ServerInitializationResult>((resolve, reject) => {
+            this.initializeLanguageClient(context);
+            resolve(new ServerInitializationResult(false, true, 'dummy'));
+        });
+    }
+
+    private initializeLanguageClient(context: ExtensionContext): void {
+        this._client = this.createLanguageClient(context);
+        const disposable = this._client.start();
+        context.subscriptions.push(disposable);
+    }
+
+    private createLanguageClient(context: ExtensionContext): LanguageClient {
+        const serverModule = context.asAbsolutePath(path.join('node_modules', 'languageserver-bigquery', 'out', 'index.js'));
+
+        const debugOptions = { execArgv: ['--nolazy', '--debug=6399'] };
+
+        // server options define how language server is started
+        // this particular form forks vscode and uses
+        // its bundled NodeJS runtime to execute specified node modules
+        const serverOptions: ServerOptions = {
+            run : { module: serverModule, transport: TransportKind.ipc },
+            debug: { module: serverModule, transport: TransportKind.ipc, options: debugOptions }
+        };
+
+        const clientOptions: LanguageClientOptions = {
+            documentSelector: ['sql'],
+            synchronize: {
+                configurationSection: 'mssql'
+            }
+        };
+
+        const client = new LanguageClient('BigQuery language client', serverOptions, clientOptions);
+
+        client.onNotification(LanguageServiceContracts.StatusChangedNotification.type, this.handleLanguageServiceStatusNotification());
+        return client;
+    }
+
+    private handleLanguageServiceStatusNotification(): NotificationHandler<LanguageServiceContracts.StatusChangeParams> {
+        return (event: LanguageServiceContracts.StatusChangeParams): void => {
+            this._statusView.languageServiceStatusChanged(event.ownerUri, event.status);
+        };
+    }
+
+    public sendRequest<P, R, E>(type: RequestType<P, R, E>, params?: P): Thenable<R> {
+        if (this._client !== undefined) {
+            const ret = this._client.sendRequest(type, params);
+            return ret;
+        }
+    }
+
+    public onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): void {
+        if (this._client !== undefined) {
+             return this._client.onNotification(type, handler);
+        }
+    }
+}

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -24,6 +24,7 @@ import {PlatformInformation} from '../models/platform';
 import {ServerInitializationResult, ServerStatusView} from './serverStatus';
 import StatusView from '../views/statusView';
 import * as LanguageServiceContracts from '../models/contracts/languageService';
+import BigQueryServiceClient from './bigquery';
 
 let opener = require('opener');
 let _channel: OutputChannel = undefined;
@@ -125,7 +126,7 @@ export interface ISqlToolsServiceClient {
 
 export class ServiceClientLocator {
     public static get instance(): ISqlToolsServiceClient {
-        return SqlToolsServiceClient.instance;
+        return BigQueryServiceClient.instance;
     }
 }
 

--- a/src/languageservice/serviceclient.ts
+++ b/src/languageservice/serviceclient.ts
@@ -104,8 +104,34 @@ class LanguageClientErrorHandler {
     }
 }
 
+export interface ISqlToolsServiceClient {
+    initialize(context: ExtensionContext): Promise<ServerInitializationResult>;
+
+    /**
+     * Send a request to the service client
+     * @param type The of the request to make
+     * @param params The params to pass with the request
+     * @returns A thenable object for when the request receives a response
+     */
+    sendRequest<P, R, E>(type: RequestType<P, R, E>, params?: P): Thenable<R>;
+
+    /**
+     * Register a handler for a notification type
+     * @param type The notification type to register the handler for
+     * @param handler The handler to register
+     */
+    onNotification<P>(type: NotificationType<P>, handler: NotificationHandler<P>): void;
+}
+
+export class ServiceClientLocator {
+    public static get instance(): ISqlToolsServiceClient {
+        return SqlToolsServiceClient.instance;
+    }
+}
+
+
 // The Service Client class handles communication with the VS Code LanguageClient
-export default class SqlToolsServiceClient {
+export default class SqlToolsServiceClient implements ISqlToolsServiceClient {
     // singleton instance
     private static _instance: SqlToolsServiceClient = undefined;
 

--- a/src/models/resultsSerializer.ts
+++ b/src/models/resultsSerializer.ts
@@ -4,7 +4,7 @@ import Constants = require('./constants');
 import os = require('os');
 import fs = require('fs');
 import Interfaces = require('./interfaces');
-import SqlToolsServerClient from '../languageservice/serviceclient';
+import { ISqlToolsServiceClient, ServiceClientLocator } from '../languageservice/serviceclient';
 import * as Contracts from '../models/contracts';
 import {RequestType} from 'vscode-languageclient';
 import * as Utils from '../models/utils';
@@ -17,7 +17,7 @@ import Telemetry from '../models/telemetry';
  *  Handles save results request from the context menu of slickGrid
  */
 export default class ResultsSerializer {
-    private _client: SqlToolsServerClient;
+    private _client: ISqlToolsServiceClient;
     private _prompter: IPrompter;
     private _vscodeWrapper: VscodeWrapper;
     private _uri: string;
@@ -25,12 +25,12 @@ export default class ResultsSerializer {
     private _isTempFile: boolean;
 
 
-    constructor(client?: SqlToolsServerClient, prompter?: IPrompter, vscodeWrapper?: VscodeWrapper) {
+    constructor(client?: ISqlToolsServiceClient, prompter?: IPrompter, vscodeWrapper?: VscodeWrapper) {
 
         if (client) {
             this._client = client;
         } else {
-            this._client = SqlToolsServerClient.instance;
+            this._client = ServiceClientLocator.instance;
         }
         if (prompter) {
             this._prompter = prompter;


### PR DESCRIPTION
Consumers now depend on abstract interface (`ISqlToolsServiceClient`)
instead of concrete implementation (`SqlToolsServiceClient`).
Implementation to use is obtained from `ServiceClientLocator`, which
allows to substitute implementations (future idea: with a config switch).

Added our own service client (`BigQueryServiceClient`), made
`ServiceClientLocator` use it instead of `SqlToolsServiceClient`.